### PR TITLE
Add link to Microsoft.Azure.Cosmos v3.33.0-preview NuGet package

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ This feature is not guaranteed to always throttle low priority requests in favou
 ## How to get started: 
 Step 1: Whitelist your account by completing the nomination form : [priority based throttling - preview request](https://forms.microsoft.com/Pages/ResponsePage.aspx?id=v4j5cvGGr0GRqy180BHbR_kUn4g8ufhFjXbbwUF1gXFUMUQzUzFZSVkzODRSRkxXM0RKVDNUSDBGNi4u)
 
-Step2: Download the Nuget Package
-[to be added]
+Step2: Download the Nuget Package [Microsoft.Azure.Cosmos v3.33.0-preview](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.33.0-preview)
 
 Step3: Send us your feedback, comments, questions using the Issues tab on this repo. 
 


### PR DESCRIPTION
[v3.33.0-preview](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.33.0-preview) seems to be the first version to include the `PriorityLevel` enum